### PR TITLE
Enable torch.autocast with ZeRO

### DIFF
--- a/deepspeed/runtime/base_optimizer.py
+++ b/deepspeed/runtime/base_optimizer.py
@@ -8,7 +8,8 @@ import torch
 
 from deepspeed.utils import logger
 from deepspeed.utils.tensor_fragment import map_to_flat_opt_states
-from deepspeed.runtime.utils import bwc_tensor_model_parallel_rank
+from deepspeed.runtime.utils import bwc_tensor_model_parallel_rank, see_memory_usage
+from deepspeed.runtime.torch_autocast import get_autocast_dtype, is_autocast_initialized
 
 
 class DeepSpeedOptimizer(object):
@@ -61,3 +62,20 @@ class ZeROOptimizer(DeepSpeedOptimizer):
                 if key == 'params':
                     continue
                 param_group[key] = value
+
+    def report_ipg_memory_usage(self, tag, param_elems, dtype=None):
+        dtypes = self.ipg_buckets.keys() if dtype is None else [dtype]
+
+        for dt in dtypes:
+            bucket = self.ipg_buckets[dt]
+            elem_count = bucket.elements + param_elems
+            percent_of_bucket_size = (100.0 * elem_count) // self.reduce_bucket_size
+            see_memory_usage(
+                f"{tag}: elems in_bucket {dt} {bucket.elements} param {param_elems} max_percent {percent_of_bucket_size}"
+            )
+
+    def get_param_comm_dtype(self, param):
+        if is_autocast_initialized():
+            return get_autocast_dtype(param)
+        else:
+            return self.communication_data_type

--- a/deepspeed/runtime/constants.py
+++ b/deepspeed/runtime/constants.py
@@ -210,6 +210,27 @@ AMP_ENABLED = "enabled"
 AMP_ENABLED_DEFAULT = False
 
 #########################################
+# Torch AMP support
+#########################################
+TORCH_AUTOCAST_FORMAT = '''
+PyTorch autocast config should be of the format:
+"torch_autocast": {
+  "enabled": true,
+  "dtype": "bfloat16",
+  "lower_precision_safe_modules": [
+    "torch.nn.modules.linear.Linear",
+    "torch.nn.modules.conv.Conv2d"
+  ]
+}
+'''
+TORCH_AUTOCAST = "torch_autocast"
+
+TORCH_AUTOCAST_ENABLED = "enabled"
+TORCH_AUTOCAST_ENABLED_DEFAULT = False
+TORCH_AUTOCAST_DTYPE = "dtype"
+TORCH_AUTOCAST_LOWER_PRECISION_SAFE_MODULES = "lower_precision_safe_modules"
+
+#########################################
 # Gradient clipping
 #########################################
 # Gradient clipping. By default, this feature is not enabled.

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -19,7 +19,7 @@ from torch.optim.lr_scheduler import _LRScheduler
 from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 from contextlib import contextmanager
 
-from typing import Callable, Dict, Union, Iterable, Container
+from typing import Callable, Dict, Union, Iterable, Container, List
 
 import deepspeed
 
@@ -95,6 +95,7 @@ from deepspeed.runtime.data_pipeline.data_routing.helper import remove_random_lt
 from deepspeed.runtime.data_pipeline.data_routing.basic_layer import RandomLayerTokenDrop
 
 from deepspeed.utils.zero_to_fp32 import get_fp32_state_dict_from_zero_checkpoint
+from deepspeed.runtime.torch_autocast import init_autocast_params, get_default_autocast_lower_precision_modules, validate_nested_autocast
 
 from .pipe.module import PipelineModule
 from .utils import get_ma_status
@@ -326,6 +327,9 @@ class DeepSpeedEngine(Module):
         # Convert model parameters from generator to list
         if not isinstance(model_parameters, list):
             model_parameters = list(model_parameters)
+
+        if self.torch_autocast_enabled():
+            init_autocast_params(self, self.torch_autocast_dtype(), self.torch_autocast_lower_precision_safe_modules())
 
         if has_optimizer:
             self._configure_optimizer(optimizer, model_parameters)
@@ -959,6 +963,16 @@ class DeepSpeedEngine(Module):
 
     def amp_params(self):
         return self._config.amp_params
+
+    def torch_autocast_enabled(self) -> bool:
+        return self._config.torch_autocast_enabled
+
+    def torch_autocast_dtype(self) -> torch.dtype:
+        return self._config.torch_autocast_dtype
+
+    def torch_autocast_lower_precision_safe_modules(self) -> List[str]:
+        module_names = self._config.torch_autocast_lower_precision_safe_modules
+        return get_default_autocast_lower_precision_modules() if module_names is None else module_names
 
     def fp16_auto_cast(self):
         return self._config.float16_config.auto_cast
@@ -2084,7 +2098,11 @@ class DeepSpeedEngine(Module):
             # We can't have this in forward prologue as the compiler compiles hooks including the forward prologue.
             self.launch_compile_passes(self.global_steps)
 
-        loss = self.module(*inputs, **kwargs)
+        validate_nested_autocast(self)
+        with torch.autocast(device_type=get_accelerator().device_name(),
+                            dtype=self.torch_autocast_dtype(),
+                            enabled=self.torch_autocast_enabled()):
+            loss = self.module(*inputs, **kwargs)
 
         if self.autotuning_profile_model_info():
             activation_mem = get_ma_status() - ma

--- a/deepspeed/runtime/torch_autocast.py
+++ b/deepspeed/runtime/torch_autocast.py
@@ -1,0 +1,100 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from typing import Iterable, Set, List, Union
+import importlib
+
+import torch
+from deepspeed.utils import logger
+
+LOWER_PRECISION_SAFE_MODULES = [
+    torch.nn.Linear,
+    torch.nn.Conv1d,
+    torch.nn.Conv2d,
+    torch.nn.Conv3d,
+]
+
+TORCH_AUTOCAST_INITIALIZED = False
+_WARNED_NESTED_AUTOCAST = False
+
+
+def _validate_auto_cast_settings(engine):
+
+    assert not engine.fp16_enabled(), "Cannot enable both torch autocast and fp16"
+    assert not engine.bfloat16_enabled(), "Cannot enable both torch autocast and bfloat16"
+    assert not engine.zero_quantized_weights(), "Cannot enable both torch autocast and zero quantized weights"
+
+    assert all(p.dtype == torch.float32
+               for p in engine.parameters()), "All parameters must be float32 for torch autocast"
+    assert engine.communication_data_type == torch.float32, "Communication data type must be float32 for torch autocast"
+
+
+def init_autocast_params(engine, dtype: torch.dtype,
+                         torch_autocast_lower_precision_safe_modules: Union[None, List[str]]) -> None:
+
+    _validate_auto_cast_settings(engine)
+    model = engine.module
+
+    if torch_autocast_lower_precision_safe_modules is None:
+        lower_precision_safe_module_classes = LOWER_PRECISION_SAFE_MODULES
+    else:
+        lower_precision_safe_module_classes = []
+        for module_name in torch_autocast_lower_precision_safe_modules:
+            try:
+                package_name, class_name = module_name.rsplit('.', 1)
+                module = importlib.import_module(package_name)
+                class_ = getattr(module, class_name)
+                lower_precision_safe_module_classes.append(class_)
+            except Exception as e:
+                raise ValueError(f"Failed to import lower precision safe module {module_name}: {e}")
+
+    for module in model.modules():
+        if module.__class__ in lower_precision_safe_module_classes:
+            for p in module.parameters(recurse=False):
+                p.autocast_dtype = dtype
+
+    global TORCH_AUTOCAST_INITIALIZED
+    TORCH_AUTOCAST_INITIALIZED = True
+
+
+def is_autocast_initialized() -> bool:
+    return TORCH_AUTOCAST_INITIALIZED
+
+
+def get_default_autocast_lower_precision_modules() -> List[str]:
+    return [f"{cls.__module__}.{cls.__name__}" for cls in LOWER_PRECISION_SAFE_MODULES]
+
+
+def get_autocast_dtype(param: torch.nn.Parameter) -> torch.dtype:
+    return param.autocast_dtype if hasattr(param, "autocast_dtype") else param.dtype
+
+
+def has_autocast_dtype(param: torch.nn.Parameter) -> bool:
+    return hasattr(param, "autocast_dtype")
+
+
+def get_all_autocast_dtypes(params: Iterable) -> Set[torch.dtype]:
+    return {get_autocast_dtype(p) for p in params}
+
+
+def sort_dtypes(dtypes: List[torch.dtype]) -> List[torch.dtype]:
+    return sorted(dtypes, key=str)
+
+
+def validate_nested_autocast(engine):
+    global _WARNED_NESTED_AUTOCAST
+
+    if torch.is_autocast_enabled():
+        if engine.torch_autocast_enabled():
+            if not _WARNED_NESTED_AUTOCAST:
+                logger.warning(
+                    "DeepSpeed detected torch.autocast context outside the engine. "
+                    "This is unnecessary when torch.autocast is already enabled through the DeepSpeed config.")
+                _WARNED_NESTED_AUTOCAST = True
+        else:
+            raise AssertionError(
+                "torch.autocast is enabled outside DeepSpeed, but not in the DeepSpeed config. "
+                "Please enable torch.autocast through the DeepSpeed config to ensure the correct communication dtype is used."
+            )

--- a/deepspeed/runtime/zero/offload_states.py
+++ b/deepspeed/runtime/zero/offload_states.py
@@ -67,6 +67,5 @@ def get_state_devices(model, state: OffloadStateTypeEnum) -> Set[torch.device]:
         return set(model.optimizer.get_hp_param_device(p, "exp_avg") for p in model.parameters()) | \
                set(model.optimizer.get_hp_param_device(p, "exp_avg_sq") for p in model.parameters())
     elif state == OffloadStateTypeEnum.contiguous_grad_buffer:
-        if model.optimizer._DeepSpeedZeroOptimizer_Stage3__ipg_bucket_flat_buffer == None:
-            return {}
-        return {model.optimizer._DeepSpeedZeroOptimizer_Stage3__ipg_bucket_flat_buffer.device}
+        return set(bucket.buffer.device for bucket in model.optimizer.ipg_buckets.values()
+                   if bucket.buffer is not None)

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -11,6 +11,9 @@ import socket
 import subprocess
 from abc import ABC, abstractmethod
 from pathlib import Path
+import random
+import numpy as np
+from typing import Callable, Any
 
 import torch
 import torch.multiprocessing as mp
@@ -505,3 +508,64 @@ def preferred_dtype():
         return torch.float16
     else:
         return torch.float32
+
+
+class EnableDeterminism:
+
+    def __init__(self, seed: int):
+        local_rank = int(os.getenv("LOCAL_RANK", "0"))
+
+        self.seed = seed + local_rank
+        self.saved_random_state = None
+        self.saved_np_random_state = None
+        self.saved_cuda_launch_blocking = None
+        self.saved_cublas_workspace_config = None
+        self.saved_deterministic_algorithms = None
+
+    def __enter__(self):
+        self.saved_random_state = random.getstate()
+        self.saved_np_random_state = np.random.get_state()
+        self.saved_acc_rng_state = get_accelerator().get_rng_state()
+        self.saved_cuda_launch_blocking = os.environ.get("CUDA_LAUNCH_BLOCKING", "")
+        self.saved_cublas_workspace_config = os.environ.get("CUBLAS_WORKSPACE_CONFIG", "")
+        self.saved_deterministic_algorithms = torch.are_deterministic_algorithms_enabled()
+
+        random.seed(self.seed)
+        np.random.seed(self.seed)
+        get_accelerator().manual_seed(self.seed)
+        get_accelerator().manual_seed_all(self.seed)
+
+        os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
+        torch.use_deterministic_algorithms(True)
+
+    def __exit__(self, type, value, traceback):
+        random.setstate(self.saved_random_state)
+        np.random.set_state(self.saved_np_random_state)
+        get_accelerator().set_rng_state(self.saved_acc_rng_state)
+        os.environ["CUDA_LAUNCH_BLOCKING"] = self.saved_cuda_launch_blocking
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = self.saved_cublas_workspace_config
+        torch.use_deterministic_algorithms(self.saved_deterministic_algorithms)
+
+
+def enable_determinism(seed: int):
+
+    def decorator(func: Callable) -> Callable:
+
+        def wrapper(*args: Any, **kwargs: Any):
+            with EnableDeterminism(seed):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def reduce_boolean_flags(flag: bool, op=all) -> bool:
+    device = get_accelerator().current_device()
+    tensor_flag = torch.tensor(1 if flag else 0, dtype=torch.int, device=device)
+    world_size = dist.get_world_size()
+    tensor_flag_buf = torch.zeros(world_size, dtype=torch.int, device=device)
+    dist.all_gather_into_tensor(tensor_flag_buf, tensor_flag)
+    list_flags = [bool(f) for f in tensor_flag_buf.tolist()]
+    return op(list_flags)

--- a/tests/unit/runtime/zero/test_zero_autocast.py
+++ b/tests/unit/runtime/zero/test_zero_autocast.py
@@ -1,0 +1,181 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from copy import deepcopy
+
+import pytest
+
+import torch
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+from unit.common import DistributedTest, enable_determinism, reduce_boolean_flags
+from unit.simple_model import SimpleModel
+from unit.util import bf16_required_version_check
+
+import deepspeed
+from deepspeed.accelerator import get_accelerator
+from deepspeed.runtime.zero import GatheredParameters
+
+RTOL = 0.1
+ATOL = 0.0
+
+
+def cls_to_qualname(cls):
+    return f"{cls.__module__}.{cls.__name__}"
+
+
+class SimpleModelWithLayerNorm(torch.nn.Module):
+
+    def __init__(self, hidden_dim, nlayers=1):
+        super(SimpleModelWithLayerNorm, self).__init__()
+        self.linears = torch.nn.ModuleList([torch.nn.Linear(hidden_dim, hidden_dim) for i in range(nlayers)])
+        self.norm = torch.nn.LayerNorm(hidden_dim)
+        self.cross_entropy_loss = torch.nn.CrossEntropyLoss()
+
+    def forward(self, x, y):
+        x = self.linears[0](x)
+        x = self.norm(x)
+        return self.cross_entropy_loss(x, y)
+
+
+def step_amp(enabled, baseline_model, baseline_optimizer, target_engine, dtype, enable_autocast_outside,
+             baseline_scaler, step, x, y, rtol, atol):
+    device_type = get_accelerator().device_name()
+
+    # Runs the forward pass with autocasting.
+    with torch.autocast(device_type=device_type, dtype=dtype, enabled=enabled):
+        baseline_optimizer.zero_grad()
+        baseline_loss = baseline_model(x, y)
+
+    baseline_scaler.scale(baseline_loss).backward()
+    baseline_scaler.step(baseline_optimizer)
+    baseline_scaler.update()
+
+    # We don't need torch.autocast here in real applications, but want to test the behavior of nested autocast.
+    with torch.autocast(device_type=device_type, dtype=dtype, enabled=enable_autocast_outside):
+        target_loss = target_engine(x, y)
+
+    # reduce-scatter in `dtype` makes a difference in the loss.
+    if step <= 1:
+        assert reduce_boolean_flags(
+            torch.allclose(baseline_loss.float(), target_loss.float(), rtol=rtol, atol=atol),
+            all), f"Losses do not match: baseline_loss={baseline_loss}, target_loss={target_loss}"
+
+    target_engine.backward(target_loss)
+    target_engine.step()
+
+
+@enable_determinism(123)
+def compare_loss(model_cls, enable, zero_stage, dtype, autocast_conf, enable_autocast_outside,
+                 lower_precision_safe_modules):
+    iteration = 5
+    hidden_dim = 10
+    lr = 0.001
+
+    if dtype == torch.bfloat16 and not bf16_required_version_check():
+        raise ValueError(
+            "DeepSpeed BFloat16 tests need torch >= 1.10, NCCL >= 2.10.3, CUDA > =11.0 and HW support for BFloat16 to run correctly"
+        )
+
+    config_dict = {
+        "train_micro_batch_size_per_gpu": 1,
+        "steps_per_print": 1,
+        "zero_optimization": {
+            "stage": zero_stage,
+        },
+        "torch_autocast": autocast_conf,
+    }
+
+    model = model_cls(hidden_dim)
+
+    deepspeed.init_distributed(dist_backend='nccl')
+
+    i = get_accelerator().current_device()
+    device = get_accelerator().current_device_name()
+    baseline_model = DDP(deepcopy(model).to(device=device, dtype=torch.float32), device_ids=[i], output_device=i)
+    baseline_optimizer = torch.optim.AdamW(baseline_model.parameters(), lr=lr, weight_decay=0.0)
+    baseline_scaler = torch.amp.GradScaler()
+
+    stage_3_enabled = config_dict["zero_optimization"]["stage"] == 3
+    if stage_3_enabled:
+        with deepspeed.zero.Init(config_dict_or_path=config_dict):
+            target_model = model_cls(hidden_dim)
+        with GatheredParameters(target_model.parameters(), modifier_rank=0):
+            for p1, p2 in zip(target_model.parameters(), model.parameters()):
+                p1.data.copy_(p2.data)
+    else:
+        target_model = deepcopy(model)
+
+    ds_optimizer = torch.optim.Adam(target_model.parameters(), lr=lr)
+    target_engine, _, _, _ = deepspeed.initialize(config=config_dict, model=target_model, optimizer=ds_optimizer)
+    train_batch_size = config_dict["train_micro_batch_size_per_gpu"]
+
+    xs = [torch.randn(train_batch_size, hidden_dim, device=device, dtype=torch.float32) for _ in range(iteration)]
+    ys = [torch.randn_like(x) for x in xs]
+
+    for i, (x, y) in enumerate(zip(xs, ys)):
+        step_amp(enable, baseline_model, baseline_optimizer, target_engine, dtype, enable_autocast_outside,
+                 baseline_scaler, i, x, y, RTOL, ATOL)
+
+    for module in target_engine.modules():
+        for p in module.parameters(recurse=False):
+            if module.__class__ in lower_precision_safe_modules:
+                assert hasattr(
+                    p, "autocast_dtype"
+                ), f"A module is in the lower precision safe list, but param does not have autocast_dtype: {module.__class__.__name__}"
+                assert p.autocast_dtype == dtype, f"dtype of a module in the lower precision safe list is not set to {dtype}: {module.__class__.__name__}"
+            else:
+                assert not hasattr(
+                    p, "autocast_dtype"
+                ), f"A module is not in the lower precision safe list, but param has autocast_dtype: {module.__class__.__name__}"
+                assert p.dtype == torch.float32, f"dtype of a module not in the lower precision safe list is not float32: {module.__class__.__name__}"
+
+    target_engine.destroy()
+
+
+@pytest.mark.parametrize("enable", [True])
+class TestZeroAutoCast(DistributedTest):
+    world_size = 2
+
+    @pytest.mark.parametrize("zero_stage", [1, 2, 3])
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+    def test(self, enable, zero_stage, dtype):
+        lower_precision_safe_modules = [torch.nn.Linear]
+        autocast_conf = {"enabled": enable, "dtype": str(dtype)}
+
+        compare_loss(SimpleModel, enable, zero_stage, dtype, autocast_conf, False, lower_precision_safe_modules)
+
+    @pytest.mark.parametrize("zero_stage", [1, 2, 3])
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+    def test_safe_modules_conf(self, enable, zero_stage, dtype):
+        lower_precision_safe_modules = [torch.nn.Linear]
+        autocast_conf = {
+            "enabled": enable,
+            "dtype": str(dtype),
+            "lower_precision_safe_modules": [cls_to_qualname(cls) for cls in lower_precision_safe_modules]
+        }
+
+        # The model has both lower precision safe and unsafe modules.
+        compare_loss(SimpleModelWithLayerNorm, enable, zero_stage, dtype, autocast_conf, False,
+                     lower_precision_safe_modules)
+
+    @pytest.mark.parametrize("zero_stage", [1])
+    @pytest.mark.parametrize("dtype", [torch.bfloat16])
+    def test_error_autocast_outside_ds(self, enable, zero_stage, dtype):
+        """Throw an error when torch.autocast is enabled outside deepspeed engine but disabled in config."""
+
+        lower_precision_safe_modules = [torch.nn.Linear]
+        autocast_conf = {
+            "enabled": False,
+            "dtype": str(dtype),
+        }
+
+        try:
+            compare_loss(SimpleModelWithLayerNorm, enable, zero_stage, dtype, autocast_conf, True,
+                         lower_precision_safe_modules)
+            pytest.fail(
+                "Expected an error when torch.autocast is enabled outside deepspeed engine but disabled in config.")
+        except AssertionError as e:
+            pass


### PR DESCRIPTION
Recreated from original PR: https://github.com/deepspeedai/DeepSpeed/pull/6993

DeepSpeed supports mixed precision training, but the behavior is different from `torch.autocast`. DeepSpeed maintains parameters and gradients both in FP32 and a lower precision (FP16/BF16) (NVIDIA Apex AMP style) and computes all modules in the lower precision  while `torch.autocast` maintains parameters in FP32 but computes only certain operators in the lower precision.
This leads to differences in:
- performance: `torch.autocast` needs downcast in forward/backward
- memory usage: DeepSpeed...